### PR TITLE
Dt/fixes

### DIFF
--- a/src/CS30/Exercises/SetConversionProofs/GenerateProof.hs
+++ b/src/CS30/Exercises/SetConversionProofs/GenerateProof.hs
@@ -2,11 +2,13 @@ module CS30.Exercises.SetConversionProofs.GenerateProof  where
 import CS30.Exercises.Data
 import CS30.Exercises.SetConversionProofs.SetExprParser
 import CS30.Exercises.SetConversionProofs.LawParser
+import Data.List --( intersect, \\ )
 
 
 data Proof = Proof SetExpr [(String, SetExpr)] deriving Show
 
 -- fxn for generating a random expression, using \cap, \cup, and \setminus operators (as specified in the assignment sheet)
+-- for testing
 generateRandEx :: Int -> ChoiceTree SetExpr
 generateRandEx i | i < 1
  = Branch [ Branch [Node (Var varName) | varName <- ["A","B","C"]] -- should I have options like (Cap (Var "A") (Var "A") ? (do this and document in comments, as a creative)
@@ -18,6 +20,37 @@ generateRandEx i
         ;opr <- nodes [Cap, Cup, SetMinus]
         ;return (opr e1 e2)
        }
+
+-- evaluate fxn, calcualtes values for expressions to test that they are valid 
+-- generates [int] representation for a set, need to compare two to evaluate 
+evaluate :: SetExpr -> [Int]
+evaluate (Var "A") = [0,1,2,3]
+evaluate (Var "B") = [0,2,4,6]
+evaluate (Var "C") = [0,1,4,5]
+evaluate (Var _v) = [] -- should never reach this case
+evaluate (Cup e1 e2) = (evaluate e1) ++ (evaluate e2)
+evaluate (Vee e1 e2) = (evaluate e1) ++ (evaluate e2)
+evaluate (Cap e1 e2) = (evaluate e1) `intersect` (evaluate e2)
+evaluate (Wedge e1 e2) = (evaluate e1) `intersect` (evaluate e2)
+evaluate (SetMinus e1 e2) = (evaluate e1) \\ (evaluate e2)
+evaluate (NotIn e) = [0,1,2,3,4,5,6] \\ (evaluate e)
+evaluate (In e) = evaluate e
+evaluate (SetBuilder e) = evaluate e
+
+-- problem because these are returning a list of lists
+-- evaluate (Power e) = powerset (evaluate e)
+-- evaluate (Subset e) = powerset (evaluate e)
+
+-- fxn for building out the powerset of a variable list
+powerset :: [a] -> [[a]]
+powerset [] = [[]]
+powerset (x:xs) = [x:ps | ps <- powerset xs] ++ powerset xs
+
+-- power
+-- in
+-- notin
+-- subset
+
 
 example1, example2, example3, example4, example5, example6, example7 :: SetExpr
 example1 = (Cap (Var "M") (Var "N"))

--- a/src/CS30/Exercises/SetConversionProofs/GenerateProof.hs
+++ b/src/CS30/Exercises/SetConversionProofs/GenerateProof.hs
@@ -28,13 +28,13 @@ evaluate (Var "A") = [0,1,2,3]
 evaluate (Var "B") = [0,2,4,6]
 evaluate (Var "C") = [0,1,4,5]
 evaluate (Var _v) = [] -- should never reach this case if var assignment happens correctly 
-evaluate (Cup e1 e2) = (evaluate e1) ++ (evaluate e2)
-evaluate (Vee e1 e2) = (evaluate e1) ++ (evaluate e2)
+evaluate (Cup e1 e2) = (evaluate e1) `union` (evaluate e2)
+evaluate (Vee e1 e2) = (evaluate e1) `union` (evaluate e2)
 evaluate (Cap e1 e2) = (evaluate e1) `intersect` (evaluate e2)
 evaluate (Wedge e1 e2) = (evaluate e1) `intersect` (evaluate e2)
 evaluate (SetMinus e1 e2) = (evaluate e1) \\ (evaluate e2)
-evaluate (NotIn e1 e2) = [0,1,2,3,4,5,6] \\ (evaluate e2)
-evaluate (In e1 e2) = evaluate e2
+evaluate (NotIn _e1 e2) = [0,1,2,3,4,5,6] \\ (evaluate e2)
+evaluate (In _e1 e2) = evaluate e2
 evaluate (SetBuilder e) = evaluate e
 
 -- TODO - how to fix this: 

--- a/src/CS30/Exercises/SetConversionProofs/GenerateProof.hs
+++ b/src/CS30/Exercises/SetConversionProofs/GenerateProof.hs
@@ -27,19 +27,20 @@ evaluate :: SetExpr -> [Int]
 evaluate (Var "A") = [0,1,2,3]
 evaluate (Var "B") = [0,2,4,6]
 evaluate (Var "C") = [0,1,4,5]
-evaluate (Var _v) = [] -- should never reach this case
+evaluate (Var _v) = [] -- should never reach this case if var assignment happens correctly 
 evaluate (Cup e1 e2) = (evaluate e1) ++ (evaluate e2)
 evaluate (Vee e1 e2) = (evaluate e1) ++ (evaluate e2)
 evaluate (Cap e1 e2) = (evaluate e1) `intersect` (evaluate e2)
 evaluate (Wedge e1 e2) = (evaluate e1) `intersect` (evaluate e2)
 evaluate (SetMinus e1 e2) = (evaluate e1) \\ (evaluate e2)
-evaluate (NotIn e) = [0,1,2,3,4,5,6] \\ (evaluate e)
-evaluate (In e) = evaluate e
+evaluate (NotIn e1 e2) = [0,1,2,3,4,5,6] \\ (evaluate e2)
+evaluate (In e1 e2) = evaluate e2
 evaluate (SetBuilder e) = evaluate e
 
+-- TODO - how to fix this: 
 -- problem because these are returning a list of lists
 -- evaluate (Power e) = powerset (evaluate e)
--- evaluate (Subset e) = powerset (evaluate e)
+-- evaluate (Subset e1 e2) = powerset (evaluate e2)
 
 -- fxn for building out the powerset of a variable list
 powerset :: [a] -> [[a]]
@@ -52,12 +53,14 @@ powerset (x:xs) = [x:ps | ps <- powerset xs] ++ powerset xs
 -- subset
 
 
-example1, example2, example3, example4, example5, example6, example7 :: SetExpr
+example1, example2, example3, example4, example6, example7 :: SetExpr
+-- example1, example2, example3, example4, example5, example6, example7 :: SetExpr
+
 example1 = (Cap (Var "M") (Var "N"))
 example2 = (Cup (Var "X") (Var "Y"))
 example3 = (SetMinus (Var "P") (Var "Q"))
 example4 = (Power (Var "K"))
-example5 = (In (SetBuilder (Var "p")))
+-- example5 = (In (SetBuilder (Var "p")))
 example6 = (Cap (Cap (Var "X") (Var "Y")) (Var "Z"))
 example7 = (Cap (Var "X") (Cap (Var "Y") (Var "Z")))
 
@@ -89,9 +92,9 @@ getStep eq@(lhs, rhs) e = case match lhs e of
                                                        [Wedge e1  e2' | e2' <- getStep eq e2]
                             recurse (Vee e1 e2)      = [Vee e1' e2  | e1' <- getStep eq e1] ++
                                                        [Vee e1  e2' | e2' <- getStep eq e2]  
-                            recurse (In e1)          = [In e1' | e1' <- getStep eq e1]
-                            recurse (NotIn e1)       = [NotIn e1' | e1' <- getStep eq e1]
-                            recurse (Subset e1)      = [Subset e1' | e1' <- getStep eq e1]
+                         --    recurse (In e1)          = [In e1' | e1' <- getStep eq e1]
+                         --    recurse (NotIn e1)       = [NotIn e1' | e1' <- getStep eq e1]
+                         --    recurse (Subset e1)      = [Subset e1' | e1' <- getStep eq e1]
                             
 
 type Subst = [(String, SetExpr)]
@@ -105,9 +108,9 @@ match (Cup e1 e1') (Cup e2 e2')           = [concat ((match e1 e2) ++ (match e1'
 match (SetMinus e1 e1') (SetMinus e2 e2') = [concat ((match e1 e2) ++ (match e1' e2'))]
 match (Wedge e1 e1') (Wedge e2 e2')       = [concat ((match e1 e2) ++ (match e1' e2'))]
 match (Vee e1 e1') (Vee e2 e2')           = [concat ((match e1 e2) ++ (match e1' e2'))]
-match (In e1) (In e2)                     = match e1 e2
-match (NotIn e1) (NotIn e2)               = match e1 e2
-match (Subset e1) (Subset e2)             = match e1 e2  
+-- match (In e1) (In e2)                     = match e1 e2
+-- match (NotIn e1) (NotIn e2)               = match e1 e2
+-- match (Subset e1) (Subset e2)             = match e1 e2  
 match _ _ = []
 
 apply :: Subst -> SetExpr -> SetExpr
@@ -119,9 +122,9 @@ apply subst (Cup e1 e2)      = Cup (apply subst e1) (apply subst e2)
 apply subst (SetMinus e1 e2) = SetMinus (apply subst e1) (apply subst e2)
 apply subst (Wedge e1 e2)    = Wedge (apply subst e1) (apply subst e2)
 apply subst (Vee e1 e2)      = Vee (apply subst e1) (apply subst e2)
-apply subst (In e)           = In (apply subst e)
-apply subst (NotIn e)        = NotIn (apply subst e)
-apply subst (Subset e)       = Subset (apply subst e)
+-- apply subst (In e)           = In (apply subst e)
+-- apply subst (NotIn e)        = NotIn (apply subst e)
+-- apply subst (Subset e)       = Subset (apply subst e)
 
 
 lookupInSubst :: String -> [(String, SetExpr)] -> SetExpr

--- a/src/CS30/Exercises/SetConversionProofs/LawParser.hs
+++ b/src/CS30/Exercises/SetConversionProofs/LawParser.hs
@@ -45,3 +45,4 @@ strToLaw :: String -> Law
 strToLaw law
    =  case parse parseLaw "" law of
                 Right st -> st
+                Left _ -> error "problem in parsing the law"

--- a/src/CS30/Exercises/SetConversionProofs/LawParser.hs
+++ b/src/CS30/Exercises/SetConversionProofs/LawParser.hs
@@ -18,10 +18,10 @@ type Equation = (SetExpr, SetExpr)
 
 -- 5 given laws from assignment sheet 
 law1, law2, law3, law4, law5 :: String 
-law1 = "cap definition:A \\cap B = \\left\\{e| e\\in A \\wedge e\\in B\\right\\}"
-law2 = "cup definition:A \\cup B = \\left\\{e| e\\in A \\vee e\\in B\\right\\}"
-law3 = "set minus definition:A \\setminus B = \\left\\{e| e\\in A \\wedge e\\notin B\\right\\}"
-law4 = "powerset definition:\\P(A) = \\left\\{e| e\\subseteq A\\right\\}"
+law1 = "cap definition:A \\cap B = \\left\\{e| e \\in A \\wedge e\\in B\\right\\}"
+law2 = "cup definition:A \\cup B = \\left\\{e| e \\in A \\vee e\\in B\\right\\}"
+law3 = "set minus definition:A \\setminus B = \\left\\{e| e \\in A \\wedge e\\notin B\\right\\}"
+law4 = "powerset definition:\\P(A) = \\left\\{e| e \\subseteq A\\right\\}"
 law5 = "identity fxn:e\\in \\left\\{e|p\\right\\} = p"
 
 laws :: [String] 

--- a/src/CS30/Exercises/SetConversionProofs/SetConversion.hs
+++ b/src/CS30/Exercises/SetConversionProofs/SetConversion.hs
@@ -59,7 +59,7 @@ breakUnderscore s
 -- fxn for generating a random expression, using \cap, \cup, and \setminus operators (as specified in the assignment sheet)
 generateRandEx :: Int -> ChoiceTree SetExpr
 generateRandEx i | i < 1
- = Branch [ Branch [Node (Var varName) | varName <- ["A","B","C"]] -- should I have options like (Cap (Var "A") (Var "A") ? (do this and document in comments, as a creative)
+ = Branch [ Branch [Node (Var varName) | varName <- ["A"]] -- should I have options like (Cap (Var "A") (Var "A") ? (do this and document in comments, as a creative)
           ]
 generateRandEx i
  = do { i' <- nodes [0..i-1]
@@ -68,6 +68,9 @@ generateRandEx i
         ;opr <- nodes [Cap, Cup, SetMinus]
         ;return (opr e1 e2)
        }
+
+-- assignVar :: SetExpr -> SetExpr -- function to iterate on a setexpr and replace variable names
+-- assignVar = foldl
 
 -- creating the choice tree for problems, 3 levels in terms of degree of nested expr
 setConversion :: [ChoiceTree ([Field], [Int])] 
@@ -147,14 +150,14 @@ showsPrec' p (Vee e1 e2)
   = showParen' (p < q) (showsPrec' q e1 ++ showSpace ++ 
          "\\vee" ++ showSpace ++ showsPrec' (q-1) e2)
     where q = 2
-showsPrec' _p (In e)
-  = ( "e \\in" ++ showSpace ++ showsPrec' (q-1) e)
+showsPrec' _p (In e) -- removing showParen maybe works, but honestly I don't know enough about set builder notation to be able to say
+  =  ("e \\in" ++ showSpace ++ showsPrec' (q-1) e)
     where q = 3
 showsPrec' _p (NotIn e)
-  = ( "e \\notin" ++ showSpace ++ showsPrec' (q-1) e)
+  =( "e \\notin" ++ showSpace ++ showsPrec' (q-1) e)
     where q = 3
-showsPrec' p (Subset e)
-  = showParen' (p < q) ( "e \\subseteq" ++ showSpace ++ showsPrec' (q-1) e)
+showsPrec' _p (Subset e)
+  =  ( "e \\subseteq" ++ showSpace ++ showsPrec' (q-1) e)
     where q = 1
 showsPrec' p (Power e)
   = showParen' (p < q) ( "\\P" ++ showsPrec' (0) e)

--- a/src/CS30/Exercises/SetConversionProofs/SetConversion.hs
+++ b/src/CS30/Exercises/SetConversionProofs/SetConversion.hs
@@ -147,11 +147,11 @@ showsPrec' p (Vee e1 e2)
   = showParen' (p < q) (showsPrec' q e1 ++ showSpace ++ 
          "\\vee" ++ showSpace ++ showsPrec' (q-1) e2)
     where q = 2
-showsPrec' p (In e)
-  = showParen' (p < q) ( "e \\in" ++ showSpace ++ showsPrec' (q-1) e)
+showsPrec' _p (In e)
+  = ( "e \\in" ++ showSpace ++ showsPrec' (q-1) e)
     where q = 3
-showsPrec' p (NotIn e)
-  = showParen' (p < q) ( "e \\notin" ++ showSpace ++ showsPrec' (q-1) e)
+showsPrec' _p (NotIn e)
+  = ( "e \\notin" ++ showSpace ++ showsPrec' (q-1) e)
     where q = 3
 showsPrec' p (Subset e)
   = showParen' (p < q) ( "e \\subseteq" ++ showSpace ++ showsPrec' (q-1) e)

--- a/src/CS30/Exercises/SetConversionProofs/SetConversion.hs
+++ b/src/CS30/Exercises/SetConversionProofs/SetConversion.hs
@@ -69,6 +69,7 @@ generateRandEx i
         ;return (opr e1 e2)
        }
 
+-- TODO - assignVar definition to go over the final expression by replacing all variables from left to right.
 -- assignVar :: SetExpr -> SetExpr -- function to iterate on a setexpr and replace variable names
 -- assignVar = foldl
 
@@ -81,7 +82,6 @@ setConversion
          ; return ([FIndented 1 [FMath (myShow expr)], FReorder "proof" (map ((map showProofLine steps) !!) order)], order)
     } | i <- [1..3]]
 
--- inverse permutation, checking in the other code 
 
 -- generating the proof question
 genProof :: ([Field],[Int]) -> Exercise -> Exercise
@@ -105,11 +105,11 @@ prec :: SetExpr -> Int
 prec (Var _) = 0
 prec (Power _) = 1
 prec (SetBuilder _) = 1
-prec (Subset _) = 1
+prec (Subset _ _) = 1
 prec (Vee _ _) = 2 
 prec (Wedge _ _) = 2 
-prec (In _) = 3
-prec (NotIn _) = 3 
+prec (In _ _) = 3
+prec (NotIn _ _) = 3 
 prec (Cap _ _) = 4
 prec (Cup _ _) = 4
 prec (SetMinus _ _) = 4
@@ -150,14 +150,14 @@ showsPrec' p (Vee e1 e2)
   = showParen' (p < q) (showsPrec' q e1 ++ showSpace ++ 
          "\\vee" ++ showSpace ++ showsPrec' (q-1) e2)
     where q = 2
-showsPrec' _p (In e) -- removing showParen maybe works, but honestly I don't know enough about set builder notation to be able to say
-  =  ("e \\in" ++ showSpace ++ showsPrec' (q-1) e)
+showsPrec' _p (In _e1 e2) -- removing showParen maybe works, but honestly I don't know enough about set builder notation to be able to say
+  =  ("e \\in" ++ showSpace ++ showsPrec' (q-1) e2)
     where q = 3
-showsPrec' _p (NotIn e)
-  =( "e \\notin" ++ showSpace ++ showsPrec' (q-1) e)
+showsPrec' _p (NotIn _e1 e2)
+  =( "e \\notin" ++ showSpace ++ showsPrec' (q-1) e2)
     where q = 3
-showsPrec' _p (Subset e)
-  =  ( "e \\subseteq" ++ showSpace ++ showsPrec' (q-1) e)
+showsPrec' _p (Subset _e1 e2)
+  =  ( "e \\subseteq" ++ showSpace ++ showsPrec' (q-1) e2)
     where q = 1
 showsPrec' p (Power e)
   = showParen' (p < q) ( "\\P" ++ showsPrec' (0) e)

--- a/src/CS30/Exercises/SetConversionProofs/SetConversion.hs
+++ b/src/CS30/Exercises/SetConversionProofs/SetConversion.hs
@@ -66,21 +66,63 @@ generateRandEx i
         ;e1 <- generateRandEx i'
         ;e2 <- generateRandEx (i - i' - 1)
         ;opr <- nodes [Cap, Cup, SetMinus]
-        ;return (opr e1 e2)
+        ;return (opr e1 e2) 
        }
+ 
+ 
+-- assignVar definition to go over the final expression by replacing all variables from left to right.
+-- creative element; ensures that there is no duplication of variables in the random expr generated as the problem
+assignVar :: SetExpr -> [String] -> (SetExpr, [String]) 
+assignVar (Var _) (x:xs) = (Var x, xs)
+assignVar (Cup e1 e2) lst 
+  = let (e1', lst') = assignVar e1 lst 
+        (e2', lst'') = assignVar e2 lst'
+    in (Cup e1' e2', lst'')
+assignVar (Cap e1 e2) lst 
+  = let (e1', lst') = assignVar e1 lst 
+        (e2', lst'') = assignVar e2 lst'
+    in (Cap e1' e2', lst'')
+assignVar (SetMinus e1 e2) lst 
+  = let (e1', lst') = assignVar e1 lst 
+        (e2', lst'') = assignVar e2 lst'
+    in (SetMinus e1' e2', lst'')
+assignVar (Vee e1 e2) lst 
+  = let (e1', lst') = assignVar e1 lst 
+        (e2', lst'') = assignVar e2 lst'
+    in (Vee e1' e2', lst'')
+assignVar (Wedge e1 e2) lst 
+  = let (e1', lst') = assignVar e1 lst 
+        (e2', lst'') = assignVar e2 lst'
+    in (Wedge e1' e2', lst'')
+assignVar (SetBuilder e) lst 
+  = let (e', lst') = assignVar e lst 
+    in (SetBuilder e', lst')
+assignVar (In e) lst 
+  = let (e', lst') = assignVar e lst 
+    in (In e', lst')
+assignVar (NotIn e) lst 
+  = let (e', lst') = assignVar e lst 
+    in (NotIn e', lst')
+assignVar (Subset e) lst 
+  = let (e', lst') = assignVar e lst 
+    in (Subset e', lst')
+assignVar (Power e) lst 
+  = let (e', lst') = assignVar e lst 
+    in (Power e', lst')
 
--- TODO - assignVar definition to go over the final expression by replacing all variables from left to right.
--- assignVar :: SetExpr -> SetExpr -- function to iterate on a setexpr and replace variable names
--- assignVar = foldl
+-- could change the laws based on level
+-- first case, diff var names
+-- last case allow duplicates
 
 -- creating the choice tree for problems, 3 levels in terms of degree of nested expr
 setConversion :: [ChoiceTree ([Field], [Int])] 
 setConversion
  = [do { expr <- generateRandEx i
-         ; let (Proof _expr steps) = generateProof parsedLaws expr
+         ; let expr' = fst (assignVar expr ["A", "B", "C"]) 
+         ; let (Proof _expr steps) = generateProof parsedLaws expr'
          ; order <- permutations (length steps)
-         ; return ([FIndented 1 [FMath (myShow expr)], FReorder "proof" (map ((map showProofLine steps) !!) order)], order)
-    } | i <- [1..3]]
+         ; return ([FIndented 1 [FMath (myShow expr')], FReorder "proof" (map ((map showProofLine steps) !!) order)], order)
+    } | i <- [2..4]]
 
 
 -- generating the proof question
@@ -105,11 +147,11 @@ prec :: SetExpr -> Int
 prec (Var _) = 0
 prec (Power _) = 1
 prec (SetBuilder _) = 1
-prec (Subset _ _) = 1
+prec (Subset _) = 1
 prec (Vee _ _) = 2 
 prec (Wedge _ _) = 2 
-prec (In _ _) = 3
-prec (NotIn _ _) = 3 
+prec (In  _) = 5
+prec (NotIn _) = 5
 prec (Cap _ _) = 4
 prec (Cup _ _) = 4
 prec (SetMinus _ _) = 4
@@ -130,38 +172,38 @@ showParen' p x = if p then
 
 showsPrec' :: Int -> SetExpr -> String
 showsPrec' _p (Var n) = n
+showsPrec' p (In e) 
+  = showParen' (p > q) ("e \\in" ++ showSpace ++ showsPrec' (q+1) e)
+    where q = 5
+showsPrec' p (NotIn e)
+  = showParen' (p > q) ( "e \\notin" ++ showSpace ++ showsPrec' (q+1) e)
+    where q = 5
 showsPrec' p (Cap e1 e2)
-  = showParen' (p < q) (showsPrec' q e1 ++ showSpace ++ 
-        "\\cap" ++ showSpace ++ showsPrec' (q-1) e2)
+  = showParen' (p > q) (showsPrec' q e1 ++ showSpace ++ 
+        "\\cap" ++ showSpace ++ showsPrec' (q+1) e2)
     where q = 4
 showsPrec' p (Cup e1 e2)
-  = showParen' (p < q) (showsPrec' q e1 ++ showSpace ++ 
-        "\\cup" ++ showSpace ++ showsPrec' (q-1) e2)
+  = showParen' (p > q) (showsPrec' q e1 ++ showSpace ++ 
+        "\\cup" ++ showSpace ++ showsPrec' (q+1) e2)
     where q = 4
 showsPrec' p (SetMinus e1 e2)
-  = showParen' (p < q) (showsPrec' q e1 ++ showSpace ++ 
-        "\\setminus" ++ showSpace ++ showsPrec' (q-1) e2)
+  = showParen' (p > q) (showsPrec' q e1 ++ showSpace ++ 
+        "\\setminus" ++ showSpace ++ showsPrec' (q+1) e2)
     where q = 4
 showsPrec' p (Wedge e1 e2)
-  = showParen' (p < q) (showsPrec' q e1 ++ showSpace ++ 
-        "\\wedge" ++ showSpace ++ showsPrec' (q-1) e2)
+  = showParen' (p > q) (showsPrec' q e1 ++ showSpace ++ 
+        "\\wedge" ++ showSpace ++ showsPrec' (q+1) e2)
     where q = 2
 showsPrec' p (Vee e1 e2)
-  = showParen' (p < q) (showsPrec' q e1 ++ showSpace ++ 
-         "\\vee" ++ showSpace ++ showsPrec' (q-1) e2)
+  = showParen' (p > q) (showsPrec' q e1 ++ showSpace ++ 
+         "\\vee" ++ showSpace ++ showsPrec' (q+1) e2)
     where q = 2
-showsPrec' _p (In _e1 e2) -- removing showParen maybe works, but honestly I don't know enough about set builder notation to be able to say
-  =  ("e \\in" ++ showSpace ++ showsPrec' (q-1) e2)
-    where q = 3
-showsPrec' _p (NotIn _e1 e2)
-  =( "e \\notin" ++ showSpace ++ showsPrec' (q-1) e2)
-    where q = 3
-showsPrec' _p (Subset _e1 e2)
-  =  ( "e \\subseteq" ++ showSpace ++ showsPrec' (q-1) e2)
+showsPrec' p (Subset e)
+  =  showParen' (p > q) ( "e \\subseteq" ++ showSpace ++ showsPrec' (q+1) e)
     where q = 1
 showsPrec' p (Power e)
-  = showParen' (p < q) ( "\\P" ++ showsPrec' (0) e)
+  = showParen' (p > q) ( "\\P" ++ showsPrec' (0) e)
     where q = 1
 showsPrec' p (SetBuilder e) 
-  = showParen' (p < q) ( "\\left\\{ e | " ++ myShow e ++ "\\right\\}")
+  = showParen' (p > q) ( "\\left\\{ e | " ++ myShow e ++ "\\right\\}")
     where q = 1

--- a/src/CS30/Exercises/SetConversionProofs/SetExprParser.hs
+++ b/src/CS30/Exercises/SetConversionProofs/SetExprParser.hs
@@ -13,8 +13,6 @@ import           Text.Megaparsec
 import           Text.Megaparsec.Char -- readFile
 import qualified Text.Megaparsec.Char.Lexer as L
 import           Control.Monad.Combinators.Expr
-import Debug.Trace
-
 
 -- datatype that we parse all expressions into 
 data SetExpr = Var String -- single variable
@@ -31,9 +29,6 @@ data SetExpr = Var String -- single variable
               deriving (Show, Eq)
 
 type Parser = ParsecT Void String Identity
-
-
-
 
 -- parse spaces (used w/ symbol and lexeme)
 spaceConsumer :: Parser ()

--- a/src/CS30/Exercises/SetConversionProofs/SetExprParser.hs
+++ b/src/CS30/Exercises/SetConversionProofs/SetExprParser.hs
@@ -23,9 +23,9 @@ data SetExpr = Var String -- single variable
               | SetMinus  SetExpr SetExpr  -- set difference
               | Wedge SetExpr SetExpr   -- and, intersection
               | Vee SetExpr SetExpr     -- or, union
-              | In SetExpr SetExpr      -- element of 
-              | NotIn SetExpr SetExpr   -- not an element of
-              | Subset SetExpr SetExpr -- subset of
+              | In  SetExpr      -- element of 
+              | NotIn SetExpr   -- not an element of
+              | Subset SetExpr -- subset of
               deriving (Show, Eq)
 
 type Parser = ParsecT Void String Identity
@@ -78,9 +78,9 @@ parseConstant = do
 --   ]
 operatorTable :: [[Operator Parser SetExpr]] -- order matters! 
 operatorTable =
-  [ [binary "\\in" In, binary "\\notin" NotIn], 
+  [ [binary "\\in" (const In), binary "\\notin" (const NotIn)], 
     [prefix "\\P" Power], 
-    [binary "\\subseteq" Subset],
+    [binary "\\subseteq" (const Subset)],
     [binary "\\cap" Cap, binary "\\cup" Cup], 
     [binary "\\setminus" SetMinus],
     [binary "\\wedge" Wedge, binary "\\vee" Vee] 

--- a/src/CS30/Exercises/SetConversionProofs/SetExprParser.hs
+++ b/src/CS30/Exercises/SetConversionProofs/SetExprParser.hs
@@ -23,9 +23,9 @@ data SetExpr = Var String -- single variable
               | SetMinus  SetExpr SetExpr  -- set difference
               | Wedge SetExpr SetExpr   -- and, intersection
               | Vee SetExpr SetExpr     -- or, union
-              | In SetExpr      -- element of 
-              | NotIn SetExpr   -- not an element of
-              | Subset SetExpr -- subset of
+              | In SetExpr SetExpr      -- element of 
+              | NotIn SetExpr SetExpr   -- not an element of
+              | Subset SetExpr SetExpr -- subset of
               deriving (Show, Eq)
 
 type Parser = ParsecT Void String Identity
@@ -67,15 +67,25 @@ parseConstant = do
   return (Var [n])
 
 -- operator table for use with makeExprParser 
+-- operatorTable :: [[Operator Parser SetExpr]] -- order matters! 
+-- operatorTable =
+--   [ [prefix "e\\in" In, prefix "e\\notin" NotIn], 
+--     [prefix "\\P" Power], 
+--     [prefix "e\\subseteq" Subset],
+--     [binary "\\cap" Cap, binary "\\cup" Cup], 
+--     [binary "\\setminus" SetMinus],
+--     [binary "\\wedge" Wedge, binary "\\vee" Vee] 
+--   ]
 operatorTable :: [[Operator Parser SetExpr]] -- order matters! 
 operatorTable =
-  [ [prefix "e\\in" In, prefix "e\\notin" NotIn], 
+  [ [binary "\\in" In, binary "\\notin" NotIn], 
     [prefix "\\P" Power], 
-    [prefix "e\\subseteq" Subset],
+    [binary "\\subseteq" Subset],
     [binary "\\cap" Cap, binary "\\cup" Cup], 
     [binary "\\setminus" SetMinus],
     [binary "\\wedge" Wedge, binary "\\vee" Vee] 
   ]
+
 -- helper function for generating an binary infix operator
 -- based on documentation for Control.Monad.Combinators.Expr
 binary :: String -> (a -> a -> a) -> Operator Parser a
@@ -112,3 +122,6 @@ parseTerm = parens parseExpr <|> exprParens parseExpr  <|> parseSetBuilder  <|> 
 -- parse a set expression (using makeExprParser)
 parseExpr :: Parser SetExpr
 parseExpr =  makeExprParser parseTerm operatorTable
+
+
+--(for all A) \P(A) = \\left\\{e| e \\in A\\right\\}


### PR DESCRIPTION
contains fixes for:

parenthesis precedence for set builder notation
parser for e \in
evaluate function
no more nonsensical/one-line proof questions