### PR TITLE
Less redundant proof

### DIFF
--- a/src/CS30/Exercises/SetConversionProofs/GenerateProof.hs
+++ b/src/CS30/Exercises/SetConversionProofs/GenerateProof.hs
@@ -71,6 +71,19 @@ generateProof laws' e = Proof e (multiSteps e)
                           ((nm,e''):_) -> (nm,e'') : multiSteps e''
 
 
+cleanProof :: Proof -> Proof
+cleanProof (Proof ie (xs)) = Proof ie (clean xs)
+
+
+clean :: [(String, SetExpr)] -> [(String, SetExpr)]
+clean []    = []
+clean [stp] = [stp]
+clean (stp1@(nm,_):stp2@(nxt_nm, nxt_e):rest) = if nxt_nm == "identity fxn" then
+                                                    clean ((nm, nxt_e):rest)
+                                                else
+                                                    stp1:clean (stp2:rest)
+
+
 getStep :: Equation -> SetExpr -> [SetExpr] -- [SetExpr] because we want to check if it's empty or not
 getStep eq@(lhs, rhs) e = case match lhs e of
                             [] -> recurse e -- If there is no substition, recursively getStep e


### PR DESCRIPTION
Added the cleanProof function that removes the redundant steps (i.e., identity fxn) to make it easier to understand for CS30 students. Haven't updated the ```SetConversion.hs```


  Original proof of example 7:
--------------------------------------------------------------
```
$ generateProof parsedLaws example7

Proof (Cap (Var "X") (Cap (Var "Y") (Var "Z")))
[("cap definition",SetBuilder (Wedge (In (Var "X")) (In (Cap (Var "Y") (Var "Z"))))),
("cap definition",SetBuilder (Wedge (In (Var "X")) (In (SetBuilder (Wedge (In (Var "Y")) (In (Var "Z"))))))),
("identity fxn",SetBuilder (Wedge (In (Var "X")) (Wedge (In (Var "Y")) (In (Var "Z")))))]
```

  After cleaning the proof of example 7
--------------------------------------------------------------
```
$ cleanProof $ generateProof parsedLaws example7

Proof (Cap (Var "X") (Cap (Var "Y") (Var "Z")))
[("cap definition",SetBuilder (Wedge (In (Var "X")) (In (Cap (Var "Y") (Var "Z"))))),
("cap definition",SetBuilder (Wedge (In (Var "X")) (Wedge (In (Var "Y")) (In (Var "Z")))))]
```